### PR TITLE
Makes it work with after_commit and transactions with multiple saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+## 0.3.0 (2020-08-03)
+
+- Changed ObjectWas initialization to wrap al all the changes for a transaction
+
+ ## 0.2.2 (2019-12-16)
+
+- Added new tests for chained methods
+- Fixed chained methods
+
+ ## 0.2.1 (2019-12-16)
+
+- Made #field_change, #from and #to public
+
+ ## 0.2.0 (2019-12-12)
+
+- Added new test and fixes styles
+- Added #field_change, #from, #to

--- a/lib/beaconable.rb
+++ b/lib/beaconable.rb
@@ -15,12 +15,13 @@ module Beaconable
   private
 
   def save_for_beacon
-    @object_was = ObjectWas.new(self).call
+    @object_was ||= ObjectWas.new(self).call
   end
 
   def fire_beacon
     if self.saved_changes?
       "#{self.class.name}Beacon".constantize.new(self, @object_was).call
     end
+    @object_was = nil
   end
 end

--- a/lib/beaconable/object_was.rb
+++ b/lib/beaconable/object_was.rb
@@ -10,7 +10,7 @@ module Beaconable
 
     def call
       hashed_object = {}
-      symbolized_column_names = object.class.column_names.map {|column_name| column_name.to_sym}
+      symbolized_column_names = object.class.column_names.map(&:to_sym)
       symbolized_column_names.each do |column_name|
         hashed_object[column_name] = object.send("#{column_name}_was")
       end

--- a/test/beaconable_test.rb
+++ b/test/beaconable_test.rb
@@ -23,7 +23,10 @@ class BeaconableTest < Minitest::Test
   end
 
   def test_new_first_name_should_fire_specific_sideeffect
-    @user.update(first_name: 'Jack')
+    ActiveRecord::Base.transaction do
+      @user.update(first_name: 'Jack')
+      @user.update(last_name: 'Roger')
+    end
     assert SideEffect.find_by(name: 'new_first_name').success?,
            'New first name should fire specific side-effect'
   end


### PR DESCRIPTION
This PR fixes the following situation:
```
ActiveRecord::Base.transaction do
  post.update!(my_column: "new value") # -> field_changed?(:my_column) == true
  post.publish! # -> field_changed?(:my_column) == false
end
```
