### PR TITLE
Add #beacon_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.4 (2022-03-14)
+
+### Improvements
+
+- Add `#beacon_metadata` & `#beacon_metadata=` method to included classes
+
 ## 0.3.3 (2020-11-02)
 
 -  Fixes a bug that causes an error when a beaconable was touch by an association without changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    beaconable (0.3.3)
+    beaconable (0.3.4)
       activerecord (>= 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3)
-      activesupport (= 6.1.3)
-    activerecord (6.1.3)
-      activemodel (= 6.1.3)
-      activesupport (= 6.1.3)
-    activesupport (6.1.3)
+    activemodel (6.1.4.6)
+      activesupport (= 6.1.4.6)
+    activerecord (6.1.4.6)
+      activemodel (= 6.1.4.6)
+      activesupport (= 6.1.4.6)
+    activesupport (6.1.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -22,8 +22,8 @@ GEM
     ast (2.4.0)
     builder (3.2.3)
     byebug (10.0.2)
-    concurrent-ruby (1.1.8)
-    i18n (1.8.9)
+    concurrent-ruby (1.1.9)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     minitest (5.11.3)
@@ -49,7 +49,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can pass `beacon_metadata` to the `object` that will be available on the **B
 
 Some uses might be:
 
-- to determine wether a certain action should be performed or not. For example when creating users in batch actions or in through the console you might want to skip just the welcome email but still perform all the other side effects associated with the user creation.
+- to determine whether a certain action should be performed or not. For example when creating users in batch actions or in through the console you might want to skip just the welcome email but still perform all the other side effects associated with the user creation.
 - to pass information that is generated / available in memory, will not be persisted in the model but is relevant in the side effects. For example, if you want to implement your own event logging system you could pass the current user id from the controller action to the beacon where you are going to create the Event.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -72,8 +72,19 @@ You can skip beacon calls if you pass true to the method `#skip_beacon`. I.E:
 
 You can pass `beacon_metadata` to the `object` that will be available on the **Beacon**.
 
+Some uses might be:
+
+- to determine wether a certain action should be performed or not. For example when creating users in batch actions or in through the console you might want to skip just the welcome email but still perform all the other side effects associated with the user creation.
+- to pass information that is generated / available in memory, will not be persisted in the model but is relevant in the side effects. For example, if you want to implement your own event logging system you could pass the current user id from the controller action to the beacon where you are going to create the Event.
+
 ```ruby
-User.create(email: "new_user@email.com", skip_welcome_user_job: true)
+User.create(
+  email: "new_user@email.com",
+  beacon_metadata: {
+    skip_welcome_user_job: true,
+    triggered_by: "admin@myapp.com"
+  }
+)
 
 # app/beacons/user_beacon.rb
 class UserBeacon < Beaconable::BaseBeacon
@@ -83,15 +94,29 @@ class UserBeacon < Beaconable::BaseBeacon
   def call
     WelcomeUserJob.perform_later(self.id) if should_perform_welcome_user_job?
     UpdateExternalServiceJob.perform_later(self.id) if field_changed? :email
+    Event.create do |event|
+      event.content = UserSerializer.new(user).event_content
+      event.ocurred_at = user.updated_at
+      if beacon_metadata.present?
+        event.triggered_by = beacon_metadata.dig(:triggered_by)
+        event.source = beacon_metadata.dig(:source)
+      end
+    end
   end
 
   private
 
   def should_perform_welcome_user_job?
-    new_entry? && !beacon_metadata[:skip_welcome_user_job]
+    new_entry? && !skip_welcome_user_job?
+  end
+
+  def skip_welcome_user_job?
+    beacon_metadata[:skip_welcome_user_job] if beacon_metadata.present?
   end
 end
 ```
+
+**Important**: once the beacon has been _fired_ the `beacon_metadata` will be cleared.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ You can skip beacon calls if you pass true to the method `#skip_beacon`. I.E:
  user.save # The user beacon won't be fired.
 ```
 
+### Beacon metadata
+
+You can pass `beacon_metadata` to the `object` that will be available on the **Beacon**.
+
+```ruby
+User.create(email: "new_user@email.com", skip_welcome_user_job: true)
+
+# app/beacons/user_beacon.rb
+class UserBeacon < Beaconable::BaseBeacon
+  alias user object
+  alias user_was object_was
+
+  def call
+    WelcomeUserJob.perform_later(self.id) if should_perform_welcome_user_job?
+    UpdateExternalServiceJob.perform_later(self.id) if field_changed? :email
+  end
+
+  private
+
+  def should_perform_welcome_user_job?
+    new_entry? && !beacon_metadata[:skip_welcome_user_job]
+  end
+end
+```
 
 ## Development
 

--- a/lib/beaconable.rb
+++ b/lib/beaconable.rb
@@ -8,6 +8,7 @@ require 'active_record'
 module Beaconable
   extend ActiveSupport::Concern
   included do
+    attr_accessor :beacon_metadata
     attr_accessor :skip_beacon
 
     before_save :save_for_beacon, unless: :skip_beacon
@@ -22,8 +23,13 @@ module Beaconable
     @object_was ||= ObjectWas.new(self).call
   end
 
+  def metadata_for_beacon
+    @beacon_metadata ||= {}
+  end
+
   def fire_beacon
-    "#{self.class.name}Beacon".constantize.new(self, @object_was).call
+    "#{self.class.name}Beacon".constantize.new(self, @object_was, metadata_for_beacon).call
     @object_was = nil
+    @beacon_metadata = nil
   end
 end

--- a/lib/beaconable.rb
+++ b/lib/beaconable.rb
@@ -23,13 +23,9 @@ module Beaconable
     @object_was ||= ObjectWas.new(self).call
   end
 
-  def metadata_for_beacon
-    @beacon_metadata ||= {}
-  end
-
   def fire_beacon
-    "#{self.class.name}Beacon".constantize.new(self, @object_was, metadata_for_beacon).call
+    "#{self.class.name}Beacon".constantize.new(self, @object_was).call
     @object_was = nil
-    @beacon_metadata = nil
+    self.beacon_metadata = nil
   end
 end

--- a/lib/beaconable/base_beacon.rb
+++ b/lib/beaconable/base_beacon.rb
@@ -2,11 +2,12 @@
 
 module Beaconable
   class BaseBeacon
-    attr_reader :object, :object_was
+    attr_reader :object, :object_was, :beacon_metadata
 
-    def initialize(object, object_was)
+    def initialize(object, object_was, beacon_metadata = {})
       @object = object
       @object_was = object_was
+      @beacon_metadata = beacon_metadata
     end
 
     def field_changed(field)

--- a/lib/beaconable/base_beacon.rb
+++ b/lib/beaconable/base_beacon.rb
@@ -4,10 +4,10 @@ module Beaconable
   class BaseBeacon
     attr_reader :object, :object_was, :beacon_metadata
 
-    def initialize(object, object_was, beacon_metadata = {})
+    def initialize(object, object_was)
       @object = object
       @object_was = object_was
-      @beacon_metadata = beacon_metadata
+      @beacon_metadata = object.beacon_metadata
     end
 
     def field_changed(field)
@@ -47,6 +47,5 @@ module Beaconable
     def new_entry?
       object_was.created_at.nil?
     end
-
   end
 end

--- a/lib/beaconable/version.rb
+++ b/lib/beaconable/version.rb
@@ -1,3 +1,3 @@
 module Beaconable
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end

--- a/test/beaconable_test.rb
+++ b/test/beaconable_test.rb
@@ -73,18 +73,18 @@ class BeaconableTest < Minitest::Test
 
   def test_beacon_metadata_is_set_at_the_instance_and_available_at_the_beacon
     user = User.new(first_name: 'Jack', last_name: 'Bauer', email: 'bauer@gmail.com')
-    user.beacon_metadata = { source: 'api'}
+    user.beacon_metadata = { source: 'api' }
     user.save!
     side_effect = SideEffect.find_by(name: 'default')
 
     assert_equal 'api', side_effect.source
   end
 
-  def test_beacon_metadata_default_is_an_empty_hash
+  def test_beacon_metadata_should_be_cleared_after_the_beacon_is_fired
     user = User.new(first_name: 'Jack', last_name: 'Bauer', email: 'bauer@gmail.com')
+    user.beacon_metadata = { source: 'api' }
     user.save!
-    side_effect = SideEffect.find_by(name: 'default')
 
-    assert_nil side_effect.source
+    assert_nil user.beacon_metadata
   end
 end

--- a/test/beaconable_test.rb
+++ b/test/beaconable_test.rb
@@ -70,4 +70,21 @@ class BeaconableTest < Minitest::Test
 
     assert_nil SideEffect.find_by(name: 'default')
   end
+
+  def test_beacon_metadata_is_set_at_the_instance_and_available_at_the_beacon
+    user = User.new(first_name: 'Jack', last_name: 'Bauer', email: 'bauer@gmail.com')
+    user.beacon_metadata = { source: 'api'}
+    user.save!
+    side_effect = SideEffect.find_by(name: 'default')
+
+    assert_equal 'api', side_effect.source
+  end
+
+  def test_beacon_metadata_default_is_an_empty_hash
+    user = User.new(first_name: 'Jack', last_name: 'Bauer', email: 'bauer@gmail.com')
+    user.save!
+    side_effect = SideEffect.find_by(name: 'default')
+
+    assert_nil side_effect.source
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,16 +20,17 @@ class SideEffect < ActiveRecord::Base
 end
 
 class UserBeacon < Beaconable::BaseBeacon
-
   alias user object
   alias user_was object_was
 
   def call
-    SideEffect.create(
-      name: 'default',
-      success: true,
-      source: beacon_metadata[:source]
-    )
+    SideEffect.create do |side_effect|
+      side_effect.name = 'default'
+      side_effect.success = true
+      if beacon_metadata.present?
+        side_effect.source = beacon_metadata.dig(:source)
+      end
+    end
     test_field_changed
     test_chained_methods
     test_destroyed_record

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,11 @@ class UserBeacon < Beaconable::BaseBeacon
   alias user_was object_was
 
   def call
-    SideEffect.create(name: 'default', success: true)
+    SideEffect.create(
+      name: 'default',
+      success: true,
+      source: beacon_metadata[:source]
+    )
     test_field_changed
     test_chained_methods
     test_destroyed_record
@@ -64,6 +68,7 @@ def setup_db
       create_table :side_effects do |t|
         t.string :name, limit: 255, null: false
         t.boolean :success, default: false
+        t.string :source, limit: 255
       end
     end
   end


### PR DESCRIPTION
This interface provides a way to pass ephemeral information to the
beacon.
The main uses might be:

* to determine whether a certain action should be performed or not. For
    example when creating users in batch actions you might want to skip
    just the welcome email but still perform all the other side effects
    associated with the user creation.
* to pass information that is generated / available in memory, will not
    be persisted in the model but is relevant in the side effects. For
    example, if you want to implement your own event logging system
    you could pass the current user id from the controller action to the
    beacon where you are going to create the Event.